### PR TITLE
Some checks on the fiber lookup container

### DIFF
--- a/lib/base/datastruct/SLookup.h
+++ b/lib/base/datastruct/SLookup.h
@@ -176,6 +176,7 @@ public:
 
     SLookupChannel* getAddress(uint addr, uint chan);
 
+    const std::string GetName() { return container; }
     virtual void print();
 
 protected:

--- a/lib/fibers/SFibersCBUnpacker.cc
+++ b/lib/fibers/SFibersCBUnpacker.cc
@@ -71,6 +71,11 @@ bool SFibersCBUnpacker::execute(ulong /*event*/, ulong /*seq_number*/, uint16_t 
 //     std::cout << "hit->ch: " << hit->ch << std::endl;
 //     SFibersChannel* lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000, hit->fiberID));
     SFibersChannel* lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000, hit->ch));
+    if (!lc) {
+        std::cerr << "No associated channel<->fiber value in " << pLookUp->GetName() << std::endl;
+        std::cerr << "The container(params.txt) might be empty or the channel, fiber information doesn't exist." << std::endl;
+        exit(0);
+    }
     SLocator loc(3);
     loc[0] = lc->m; // mod;
     loc[1] = lc->l; // lay;

--- a/lib/fibers/SFibersDDUnpacker.cc
+++ b/lib/fibers/SFibersDDUnpacker.cc
@@ -212,6 +212,11 @@ bool SFibersDDUnpacker::decode(uint16_t subevtid, float* data, size_t length)
     Float_t veto_thr = pDDUnpackerPar->getVetoThreshold(channel);
 
     SFibersChannel* lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(fake_address, channel));
+    if (!lc) {
+        std::cerr << "No associated channel<->fiber value in " << pLookUp->GetName() << std::endl;
+        std::cerr << "The container(params.txt) might be empty or the channel, fiber information doesn't exist." << std::endl;
+        exit(0);
+    }
     SLocator loc(3);
     loc[0] = lc->m; // mod;
     loc[1] = lc->l; // lay;

--- a/lib/fibers/SFibersHLDUnpacker.cc
+++ b/lib/fibers/SFibersHLDUnpacker.cc
@@ -66,6 +66,11 @@ bool SFibersHLDUnpacker::execute(ulong /*event*/, ulong /*seq_number*/, uint16_t
     if (!hit) return false;
 
     SFibersChannel* lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000, hit->fiberID) );
+    if (!lc) {
+        std::cerr << "No associated channel<->fiber value in " << pLookUp->GetName() << std::endl;
+        std::cerr << "The container(params.txt) might be empty or the channel, fiber information doesn't exist." << std::endl;
+        exit(0);
+    }
     SLocator loc(3);
     loc[0] = lc->m; // mod;
     loc[1] = lc->l; // lay;

--- a/lib/fibers/SFibersPMIUnpacker.cc
+++ b/lib/fibers/SFibersPMIUnpacker.cc
@@ -67,6 +67,11 @@ bool SFibersPMIUnpacker::execute(ulong /*event*/, ulong /*seq_number*/, uint16_t
     if (!hit) return false;
 
     SFibersChannel* lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000, hit->fiberID));
+    if (!lc) {
+        std::cerr << "No associated channel<->fiber value in " << pLookUp->GetName() << std::endl;
+        std::cerr << "The container(params.txt) might be empty or the channel, fiber information doesn't exist." << std::endl;
+        exit(0);
+    }
     SLocator loc(3);
     loc[0] = lc->m; // mod;
     loc[1] = lc->l; // lay;

--- a/lib/fibers/SFibersPetirocUnpacker.cc
+++ b/lib/fibers/SFibersPetirocUnpacker.cc
@@ -66,6 +66,11 @@ bool SFibersPetirocUnpacker::execute(ulong /*event*/, ulong /*seq_number*/, uint
     if (!hit) return false;
 
     SFibersChannel* lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000, hit->fiberID) );
+    if (!lc) {
+        std::cerr << "No associated channel<->fiber value in " << pLookUp->GetName() << std::endl;
+        std::cerr << "The container(params.txt) might be empty or the channel, fiber information doesn't exist." << std::endl;
+        exit(0);
+    }
     SLocator loc(3);
     loc[0] = lc->m; // mod;
     loc[1] = lc->l; // lay;

--- a/lib/fibers/SFibersTPUnpacker.cc
+++ b/lib/fibers/SFibersTPUnpacker.cc
@@ -68,6 +68,11 @@ bool SFibersTPUnpacker::execute(ulong /*event*/, ulong /*seq_number*/, uint16_t 
     if (!hit) return false;
 
     SFibersChannel* lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000, hit->channelID));
+    if (!lc) {
+        std::cerr << "No associated channel<->fiber value in " << pLookUp->GetName() << std::endl;
+        std::cerr << "The container(params.txt) might be empty or the channel, fiber information doesn't exist." << std::endl;
+        exit(0);
+    }
     SLocator loc(3);
     loc[0] = lc->m; // mod;
     loc[1] = lc->l; // lay;

--- a/lib/fibers/SFibersTTreeUnpacker.cc
+++ b/lib/fibers/SFibersTTreeUnpacker.cc
@@ -66,6 +66,11 @@ bool SFibersTTreeUnpacker::execute(ulong /*event*/, ulong /*seq_number*/, uint16
     if (!hit) return false;
 
     SFibersChannel* lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000, hit->fiberID) );
+    if (!lc) {
+        std::cerr << "channel<->fiber association insufficient in " << pLookUp->GetName() << std::endl;
+        std::cerr << "The container(params.txt) might be empty or the channel, fiber information doesn't exist." << std::endl;
+        exit(0);
+    }
     SLocator loc(3);
     loc[0] = lc->m; // mod;
     loc[1] = lc->l; // lay;


### PR DESCRIPTION
Provides an indication when the fiber lookup table in the params.txt file is constructed erroneously. It still exits with segmentation fault.