### PR TITLE
Generating early version of the SSiPMHits branch

### DIFF
--- a/dst/dst_4to1.cc
+++ b/dst/dst_4to1.cc
@@ -6,6 +6,7 @@
 #include "SFibersDDUnpacker.h"
 #include "SFibersDetector.h"
 #include "SFibersLookup.h"
+#include "SMultiFibersLookup.h"
 #include "SFibersTP4to1Unpacker.h"
 #include "SLookup.h"
 #include "STP4to1Source.h"
@@ -131,6 +132,7 @@ int main(int argc, char** argv)
     detm->initCategories();
 
     pm()->addLookupContainer("TPLookupTable", std::make_unique<SFibersLookupTable>("TPLookupTable", 0x1000, 0x1fff, 20000));
+    pm()->addLookupContainer("4to1SiPMtoFibersLookupTable", std::make_unique<SMultiFibersLookupTable>("4to1SiPMtoFibersLookupTable", 0x1000, 0x1fff, 20000));
     
     // initialize tasks
     STaskManager* tm = STaskManager::instance();

--- a/dst/dst_4to1.cc
+++ b/dst/dst_4to1.cc
@@ -130,7 +130,7 @@ int main(int argc, char** argv)
     detm->initParameterContainers();
     detm->initCategories();
 
-    pm()->addLookupContainer("FibersPMILookupTable", std::make_unique<SFibersLookupTable>("FibersPMILookupTable", 0x1000, 0x1fff, 20000));
+    pm()->addLookupContainer("TPLookupTable", std::make_unique<SFibersLookupTable>("TPLookupTable", 0x1000, 0x1fff, 20000));
     
     // initialize tasks
     STaskManager* tm = STaskManager::instance();

--- a/lib/base/datasources/STP4to1Extractor.cc
+++ b/lib/base/datasources/STP4to1Extractor.cc
@@ -150,7 +150,7 @@ bool STP4to1Extractor::write_to_tree(std::vector<std::shared_ptr<TP4to1Hit>> & h
         }
         SFibersChannel* lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000,hits[i]->channelID) );
         if(!lc) {
-            printf("TOFPET2 Ch%d missing. Check params.txt.\n", hits[i]->channelID);
+//            fprintf(stderr, "STP4to1Extractor TOFPET2 Ch%d missing. Check params.txt.\n", hits[i]->channelID);
         } else {
             pHit->setChannel(hits[i]->channelID);
             pHit->setAddress(lc->m, lc->l, lc->s, lc->side);

--- a/lib/base/datasources/STP4to1Extractor.cc
+++ b/lib/base/datasources/STP4to1Extractor.cc
@@ -2,6 +2,7 @@
 #include "STP4to1Extractor.h"
 #include "SFibersIdentification.h"
 #include "SUnpacker.h"
+#include "SFibersLookup.h"
 #include "SLookup.h"
 #include "SSiPMHit.h"
 #include "SCategory.h"
@@ -129,6 +130,9 @@ bool STP4to1Extractor::write_to_tree(std::vector<std::shared_ptr<TP4to1Hit>> & h
         return false;
     }
 
+    SFibersLookupTable* pLookUp;
+    pLookUp = dynamic_cast<SFibersLookupTable*>(pm()->getLookupContainer("TPLookupTable"));
+    SLocator loc(3);
     int n_hits = hits.size();
     for (int i = 0; i < n_hits; i++)
     {
@@ -144,9 +148,15 @@ bool STP4to1Extractor::write_to_tree(std::vector<std::shared_ptr<TP4to1Hit>> & h
                 std::cerr << "Error in STP4to1Extractor.cc: no pHit category!" << std::endl;
             }
         }
-        pHit->setAddress(loc[0]);
-        pHit->setQDC(hits[i]->energy);
-        pHit->setTime(hits[i]->time);
+        SFibersChannel* lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000,hits[i]->channelID) );
+        if(!lc) {
+            printf("TOFPET2 Ch%d missing. Check params.txt.\n", hits[i]->channelID);
+        } else {
+            pHit->setChannel(hits[i]->channelID);
+            pHit->setAddress(lc->m, lc->l, lc->s, lc->side);
+            pHit->setQDC(hits[i]->energy);
+            pHit->setTime(hits[i]->time);
+        }
     }
  
 return 0;    

--- a/lib/base/datasources/STP4to1Source.cc
+++ b/lib/base/datasources/STP4to1Source.cc
@@ -60,7 +60,7 @@ bool STP4to1Source::open()
         return false;
     }
     entries_counter = 0;
-    t = (TTree*)input_file->Get("data");
+    t = (TTree*)input_file->Get("events");
     nentries=t->GetEntries();
     std::cout << "nentries " << nentries << std::endl;
 
@@ -90,7 +90,7 @@ bool STP4to1Source::readCurrentEvent()
     std::vector<std::shared_ptr<TP4to1Hit>> hits;
     
     SFibersLookupTable* pLookUp;
-    pLookUp = dynamic_cast<SFibersLookupTable*>(pm()->getLookupContainer("FibersPMILookupTable")); //TODO CHANGE THE CONTAINER NAME AFTER MERGE TO FibersTPLookupTable (ALSO IN OTHER PLACES)
+    pLookUp = dynamic_cast<SFibersLookupTable*>(pm()->getLookupContainer("TPLookupTable"));
     SLocator loc(3);
 
     if (state == DONE) { return false; }

--- a/lib/base/datasources/STP4to1Source.cc
+++ b/lib/base/datasources/STP4to1Source.cc
@@ -89,9 +89,9 @@ bool STP4to1Source::readCurrentEvent()
     const double ps_to_ns = 1E3;
     std::vector<std::shared_ptr<TP4to1Hit>> hits;
     
-    SFibersLookupTable* pLookUp;
-    pLookUp = dynamic_cast<SFibersLookupTable*>(pm()->getLookupContainer("TPLookupTable"));
-    SLocator loc(3);
+//    SFibersLookupTable* pLookUp;
+//    pLookUp = dynamic_cast<SFibersLookupTable*>(pm()->getLookupContainer("TPLookupTable"));
+//    SLocator loc(3);
 
     if (state == DONE) { return false; }
 

--- a/lib/base/datastruct/SCategory.h
+++ b/lib/base/datastruct/SCategory.h
@@ -57,7 +57,7 @@ public:
         CatSiPMHit,        ///< SiPM hits raw data (4 to 1 coupling)
                            // tracks
                            // Limit
-        CatSiPMClus,       ///< SiPM clusters
+//        CatSiPMClus,       ///< SiPM clusters
         CatLimitDoNotUse,  ///< holds size of the category list
         CatNone,           ///< Clear category list in SLoop
     };

--- a/lib/base/datastruct/SLookup.h
+++ b/lib/base/datastruct/SLookup.h
@@ -102,7 +102,9 @@ public:
      */
     SLookupChannel* getChannel(uint chan)
     {
-//         std::cout << "chan: " << chan << " nchan: " << nchan << std::endl;
+        if(chan > nchan) {
+            fprintf(stderr, "SLooupChannel finds %d > %d. Check channel mapping. Will abort.\n", chan, nchan);
+        }
         assert(chan < nchan);
         return channels[chan].get();
     }
@@ -120,7 +122,7 @@ public:
  * The default implementation provides three mapping addreses: module, layer,
  * channel. The respective entry in the lookup table looks following:
  *
- *     addres channel        module layer channel
+ *     address channel        module layer channel
  *
  * where:
  *  * `address` - a hex value of board address (in te unpacker it is equivalent

--- a/lib/fibers/CMakeLists.txt
+++ b/lib/fibers/CMakeLists.txt
@@ -33,9 +33,9 @@ SIFI_GENERATE_LIBRARY(
         SFibersClusterFinderPar.cc
         SFibersCluster.cc
         SFibersIdentification.cc
-        SSiPMCluster.cc
-        SSiPMLookup.cc
-        SSiPMClusterFinder.cc
+        #        SSiPMCluster.cc
+        #        SSiPMLookup.cc
+        #        SSiPMClusterFinder.cc
     HEADERS
         SFibersDetector.h
         SFibersGeomPar.h
@@ -67,9 +67,9 @@ SIFI_GENERATE_LIBRARY(
         SFibersClusterFinderPar.h
         SFibersCluster.h
         SFibersIdentification.h
-        SSiPMCluster.h
-        SSiPMLookup.h
-        SSiPMClusterFinder.h
+        #        SSiPMCluster.h
+        #        SSiPMLookup.h
+        #        SSiPMClusterFinder.h
 
     PRIVATE_LIBRARIES
         ROOT::Core

--- a/lib/fibers/CMakeLists.txt
+++ b/lib/fibers/CMakeLists.txt
@@ -7,6 +7,7 @@ SIFI_GENERATE_LIBRARY(
         SFibersGeomPar.cc
         SFibersUnpacker.cc
         SFibersLookup.cc
+        SMultiFibersLookup.cc
         SFibersPMIUnpacker.cc
         SFibersCBUnpacker.cc
         SFibersTPUnpacker.cc
@@ -41,6 +42,7 @@ SIFI_GENERATE_LIBRARY(
         SFibersGeomPar.h
         SFibersUnpacker.h
         SFibersLookup.h
+        SMultiFibersLookup.h
         SFibersPMIUnpacker.h
         SFibersCBUnpacker.h
         SFibersTPUnpacker.h

--- a/lib/fibers/Linkdef.h
+++ b/lib/fibers/Linkdef.h
@@ -20,7 +20,7 @@
 #pragma link C++ class SFibersHit+;
 #pragma link C++ class SFibersHitSim+;
 #pragma link C++ class SFibersCluster+;
-#pragma link C++ class SSiPMCluster+;
+//#pragma link C++ class SSiPMCluster+;
 
 // clang-format on
 

--- a/lib/fibers/SFibersDetector.cc
+++ b/lib/fibers/SFibersDetector.cc
@@ -80,10 +80,10 @@ bool SFibersDetector::initTasks()
     else
     {
         addTask(new SFibersUnpacker(), 0);
-        addTask(new SSiPMClusterFinder(), 1);
-        addTask(new SFibersCalibrator(), 2);
-        addTask(new SFibersHitFinder(), 3);
-        addTask(new SFibersClusterFinder(), 4);
+//        addTask(new SSiPMClusterFinder(), 1);
+        addTask(new SFibersCalibrator(), 1);
+        addTask(new SFibersHitFinder(), 2);
+        addTask(new SFibersClusterFinder(), 3);
     }
 
     return true;
@@ -143,8 +143,8 @@ bool SFibersDetector::initCategories()
     size_t sizes_SiPM[1];
     sizes_SiPM[0] = modules*layers*fibers;
     
-    size_t size_SiPM_cluster[1];
-    size_SiPM_cluster[0] = 20;
+//    size_t size_SiPM_cluster[1];
+//    size_SiPM_cluster[0] = 20;
 
     if (isSimulation())
     {
@@ -163,8 +163,8 @@ bool SFibersDetector::initCategories()
             return false;
         if (!dm->registerCategory(SCategory::CatSiPMHit, "SSiPMHit", 1, sizes_SiPM, false))
             return false;
-        if (!dm->registerCategory(SCategory::CatSiPMClus, "SSiPMCluster", 1, size_SiPM_cluster, false))
-            return false;
+//        if (!dm->registerCategory(SCategory::CatSiPMClus, "SSiPMCluster", 1, size_SiPM_cluster, false))
+//            return false;
         if (!dm->registerCategory(SCategory::CatFibersCal, "SFibersCal", 3, sizes, false))
             return false;
         if (!dm->registerCategory(SCategory::CatFibersHit, "SFibersHit", 3, sizes, false))

--- a/lib/fibers/SFibersIdentification.cc
+++ b/lib/fibers/SFibersIdentification.cc
@@ -54,7 +54,7 @@ bool SFibersIdentification::finalize()
         std::vector<std::shared_ptr<fibAddress>> fibOnlyAddresses;
         SFibersChannel* lc;
         SFibersLookupTable* pLookUp;
-        pLookUp = dynamic_cast<SFibersLookupTable*>(pm()->getLookupContainer("FibersPMILookupTable"));
+        pLookUp = dynamic_cast<SFibersLookupTable*>(pm()->getLookupContainer("TPLookupTable") );
         UInt_t fakeSiPMID = -1;
         
         for(int j = 0; j < n_fibers_per_SiPM; j++)

--- a/lib/fibers/SFibersIdentification.cc
+++ b/lib/fibers/SFibersIdentification.cc
@@ -19,7 +19,7 @@
 
 #include"TFile.h"
 #include"TTree.h"
-#include "SFibersLookup.h"
+#include "SMultiFibersLookup.h"
 
 /**
  * Constructor. Requires ...
@@ -49,28 +49,34 @@ bool SFibersIdentification::finalize()
     return true;
 }
 
- std::vector<std::shared_ptr<fibAddress>> SFibersIdentification::get4to1FiberFromSiPM(UInt_t SiPMID){
+std::vector<std::shared_ptr<fibAddress>> SFibersIdentification::get4to1FiberFromSiPM(UInt_t SiPMID){
     
         std::vector<std::shared_ptr<fibAddress>> fibOnlyAddresses;
-        SFibersChannel* lc;
-        SFibersLookupTable* pLookUp;
-        pLookUp = dynamic_cast<SFibersLookupTable*>(pm()->getLookupContainer("TPLookupTable") );
-        UInt_t fakeSiPMID = -1;
-        
-        for(int j = 0; j < n_fibers_per_SiPM; j++)
-        {
-            fakeSiPMID=SiPMID*n_fibers_per_SiPM+j;
-            lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000, SiPMID));
-            if(!lc) {
-                printf("TOFPET2 Ch%d missing. Check params.txt.\n", SiPMID);
-            } else {
-                fibOnlyAddress->mod=lc->m;
-                fibOnlyAddress->lay=lc->l;
-                fibOnlyAddress->fi=lc->s;
-                fibOnlyAddress->side=lc->side;
-                fibOnlyAddresses.push_back(fibOnlyAddress);
-            }
-        }        
+        SMultiFibersChannel* lc;
+        SMultiFibersLookupTable* pLookUp;
+        pLookUp = dynamic_cast<SMultiFibersLookupTable*>(pm()->getLookupContainer("4to1SiPMtoFibersLookupTable") );
+//        lc = dynamic_cast<SMultiFibersChannel*>(pLookUp->getAddress(0x1000, SiPMID) );
+//seg faults when the SiPMID does not exist, check params.txt
+        lc = dynamic_cast<SMultiFibersChannel*>(pLookUp->getAddress(0x1000, 55) );
+        std::vector<std::vector<std::string> > vec = lc->vecFiberAssociations;
+        lc->print();
+//        std::cout << lc->m << " " << lc->l << " " << lc->s << std::endl;
+//        UInt_t fakeSiPMID = -1;
+//        
+//        for(int j = 0; j < n_fibers_per_SiPM; j++)
+//        {
+//            fakeSiPMID=SiPMID*n_fibers_per_SiPM+j;
+//            lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000, SiPMID));
+//            if(!lc) {
+//                printf("TOFPET2 Ch%d missing. Check params.txt.\n", SiPMID);
+//            } else {
+//                fibOnlyAddress->mod=lc->m;
+//                fibOnlyAddress->lay=lc->l;
+//                fibOnlyAddress->fi=lc->s;
+//                fibOnlyAddress->side=lc->side;
+//                fibOnlyAddresses.push_back(fibOnlyAddress);
+//            }
+//        }        
         return fibOnlyAddresses;
 }
 
@@ -88,30 +94,30 @@ std::vector<std::shared_ptr<identifiedFiberData>> SFibersIdentification::identif
     std::vector<std::shared_ptr<fibAddress>> fibOnlyAddresses;
     for (int i = 0; i < n_hits; i++) //
     {
-       //get a vector of fiber IDs from SiPM ID, write it to fibOnlyAddresses vector:
+//       //get a vector of fiber IDs from SiPM ID, write it to fibOnlyAddresses vector:
         fibOnlyAddresses=get4to1FiberFromSiPM(hits[i]->channelID);
-       //access the contents of the fibOnlyAddresses vector:
-//              for (int j = 0; j < fibOnlyAddresses.size(); j++){
-//              std::cout << fibOnlyAddresses[j]->mod << " " << fibOnlyAddresses[j]->lay << " " << fibOnlyAddresses[j]->fi << " " << fibOnlyAddresses[j]->side << " " << std::endl;
-//         }
-        
-     //   //do something with the obtained fibOnlyAddresses vector
+//       //access the contents of the fibOnlyAddresses vector:
+////              for (int j = 0; j < fibOnlyAddresses.size(); j++){
+////              std::cout << fibOnlyAddresses[j]->mod << " " << fibOnlyAddresses[j]->lay << " " << fibOnlyAddresses[j]->fi << " " << fibOnlyAddresses[j]->side << " " << std::endl;
+////         }
+//        
+//     //   //do something with the obtained fibOnlyAddresses vector
         fibOnlyAddresses.clear();
     }
-    
-    //change the code below by inserting the fiber identification algorithm and based on the algorithm, fill the allFibData structure for all subevents
-    int n_subevents = 5; //number of subevents
-    for (int i = 0; i < n_subevents; i++)
-    {
-        fibData->energyL=0.0;
-        fibData->timeL=0.0;
-        fibData->energyR=0.0;
-        fibData->timeR=0.0;
-        fibData->mod=0;
-        fibData->lay=0;
-        fibData->fi=0;
-        allFibData.push_back(fibData);
-    }
+//    
+//    //change the code below by inserting the fiber identification algorithm and based on the algorithm, fill the allFibData structure for all subevents
+//    int n_subevents = 5; //number of subevents
+//    for (int i = 0; i < n_subevents; i++)
+//    {
+//        fibData->energyL=0.0;
+//        fibData->timeL=0.0;
+//        fibData->energyR=0.0;
+//        fibData->timeR=0.0;
+//        fibData->mod=0;
+//        fibData->lay=0;
+//        fibData->fi=0;
+//        allFibData.push_back(fibData);
+//    }
     
 return allFibData;    
 }

--- a/lib/fibers/SFibersIdentification.cc
+++ b/lib/fibers/SFibersIdentification.cc
@@ -60,12 +60,16 @@ bool SFibersIdentification::finalize()
         for(int j = 0; j < n_fibers_per_SiPM; j++)
         {
             fakeSiPMID=SiPMID*n_fibers_per_SiPM+j;
-            lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000, fakeSiPMID));
-            fibOnlyAddress->mod=lc->m;
-            fibOnlyAddress->lay=lc->l;
-            fibOnlyAddress->fi=lc->s;
-            fibOnlyAddress->side=lc->side;
-            fibOnlyAddresses.push_back(fibOnlyAddress);
+            lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000, SiPMID));
+            if(!lc) {
+                printf("TOFPET2 Ch%d missing. Check params.txt.\n", SiPMID);
+            } else {
+                fibOnlyAddress->mod=lc->m;
+                fibOnlyAddress->lay=lc->l;
+                fibOnlyAddress->fi=lc->s;
+                fibOnlyAddress->side=lc->side;
+                fibOnlyAddresses.push_back(fibOnlyAddress);
+            }
         }        
         return fibOnlyAddresses;
 }

--- a/lib/fibers/SFibersTP4to1Unpacker.cc
+++ b/lib/fibers/SFibersTP4to1Unpacker.cc
@@ -16,7 +16,7 @@
 #include "SFibersRaw.h"
 #include "SLocator.h" // for SLocator
 #include "SLookup.h"  // for SLookupChannel, SLookupTable
-#include "SPMISource.h"
+//#include "SPMISource.h"
 #include "STPSource.h"
 #include "SFibersIdentification.h" //for identifiedFiberData structure. careful! is it a cross reference?
 #include "SiFi.h"

--- a/lib/fibers/SMultiFibersLookup.cc
+++ b/lib/fibers/SMultiFibersLookup.cc
@@ -1,0 +1,97 @@
+// @(#)lib/fibers:$Id$
+// Author: Rafal Lalik  18/11/2017
+
+/*************************************************************************
+ * Copyright (C) 2017-2018, Rafał Lalik.                                 *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $SiFiSYS/LICENSE.                         *
+ * For the list of contributors see $SiFiSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "SMultiFibersLookup.h"
+
+#include <cassert>    // for assert
+#include <inttypes.h> // for SCNu8
+
+/**
+ * \class SFibersLookupTable
+\ingroup lib_fibers
+
+A unpacker task.
+
+\sa STask
+*/
+
+/**
+ *
+ *
+ *
+ *
+ */
+void tokenize(std::string str, std::vector<std::string> &token_v, char delimiter = '/'){
+    size_t start = str.find_first_not_of(delimiter), end=start;
+    while (start != std::string::npos) {
+        // Find next occurence of delimiter
+        end = str.find(delimiter, start);
+        // Push back the token found into vector
+        token_v.push_back(str.substr(start, end-start));
+        // Skip all occurences of the delimiter to find new start
+        start = str.find_first_not_of(delimiter, end);
+    }
+}
+/**
+ * buffer contains only the max four fiber addresses
+ *
+ *
+ */
+uint SMultiFibersChannel::read(const char* buffer)
+{
+    std::string strBuffer = std::string(buffer);
+    std::replace( strBuffer.begin(), strBuffer.end(), ')', '\0');
+    std::vector<std::string> segment;
+    tokenize(strBuffer, segment, '(');
+    for(int i=0; i < segment.size(); ++i) {
+            std::vector<std::string> token;
+            tokenize(segment[i], token, ',');
+            if(token.size() == 4) {
+                if(token[0]!="" && token[1]!="" && token[2]!="" && token[3]!="") {
+                    vecFiberAssociations.push_back(token);
+                }
+            } else {
+                fprintf(stderr, "SMultiFibersChannel: There is a problem with your addressing. Check params.txt.\n");
+            }
+    }
+    return 0; //unused, just for backwards compatibility
+}
+
+uint SMultiFibersChannel::write(char* buffer, size_t n) const
+{
+//    uint cnt = snprintf(buffer, n, "%3d  %3d  %3d   %c", m, l, s, side);
+//    if (cnt < 0) return cnt;
+//    if (cnt < n) return 0;
+//    return cnt;
+    return 0;
+}
+
+void SMultiFibersChannel::print(bool newline, const char* prefix) const
+{
+    for(int i=0; i < vecFiberAssociations.size(); ++i) {
+        for(int j=0; j < vecFiberAssociations[i].size(); ++j) {
+            printf("%s ", vecFiberAssociations[i][j].c_str() );
+        }
+    }
+    printf("\n");
+}
+
+uint64_t SMultiFibersChannel::quickHash() const
+{
+//    return SLookupChannel::quickHash() | (uint64_t)side << 32;
+    return 0;
+}
+
+void SMultiFibersChannel::fromHash(uint64_t hash)
+{
+//    SLookupChannel::fromHash(hash);
+//    side = hash >> 32 & 0xff;
+}

--- a/lib/fibers/SMultiFibersLookup.h
+++ b/lib/fibers/SMultiFibersLookup.h
@@ -1,0 +1,59 @@
+// @(#)lib/fibers:$Id$
+// Author: Rafal Lalik  18/11/2017
+
+/*************************************************************************
+ * Copyright (C) 2017-2018, Rafał Lalik.                                 *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $SiFiSYS/LICENSE.                         *
+ * For the list of contributors see $SiFiSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef SMULTIFIBERSLOOKUP_H
+#define SMULTIFIBERSLOOKUP_H
+
+
+#include "sifi_export.h"
+
+#include "SLookup.h"
+
+#include <cstdio>
+#include <memory> // for make_unique, unique_ptr
+#include <stdint.h>
+#include <sys/types.h> // for uint
+/**
+ * 
+ * 
+ * 
+ */
+struct SIFI_EXPORT SMultiFibersChannel : public SLookupChannel
+{
+    /// handles the association of max four fibers to a SiPM
+    std::vector<std::vector<std::string> > vecFiberAssociations;
+    char side; ///< side of a fiber, either 'l' or 'r'
+
+    SMultiFibersChannel() {}
+    virtual ~SMultiFibersChannel() {}
+
+    virtual uint read(const char* buffer) override;
+    virtual uint write(char* buffer, size_t n) const override;
+    virtual void print(bool newline = true, const char* prefix = "") const override;
+    virtual uint64_t quickHash() const override;
+    virtual void fromHash(uint64_t hash) override;
+};
+
+class SIFI_EXPORT SMultiFibersLookupTable : public SLookupTable
+{
+public:
+    using SLookupTable::SLookupTable;
+    virtual ~SMultiFibersLookupTable() = default;
+
+    // methods
+    void tokenize(std::string str, std::vector<std::string> &token_v, char delimiter);
+    virtual std::unique_ptr<SLookupChannel> createChannel() const override
+    {
+        return std::make_unique<SMultiFibersChannel>();
+    }
+};
+
+#endif /* SMULTIFIBERSLOOKUP_H */

--- a/lib/fibers/SSiPMClusterFinder.cc
+++ b/lib/fibers/SSiPMClusterFinder.cc
@@ -52,12 +52,12 @@ bool SSiPMClusterFinder::init()
         return false;
     }
     
-    catSiPMsCluster = sifi()->getCategory(SCategory::CatSiPMClus);
-    
-    if(!catSiPMsCluster)
-    {
-        std::cerr << "No CatSiPMClus category!" << std::endl;
-    }
+//    catSiPMsCluster = sifi()->getCategory(SCategory::CatSiPMClus);
+//    
+//    if(!catSiPMsCluster)
+//    {
+//        std::cerr << "No CatSiPMClus category!" << std::endl;
+//    }
     
     pLookup = dynamic_cast<SSiPMLookupTable*>(pm()->getLookupContainer("SiPMLookupTable")); // TODO transfer this to STP4to1source?
     

--- a/lib/fibers/SSiPMHit.h
+++ b/lib/fibers/SSiPMHit.h
@@ -29,6 +29,7 @@ protected:
     Int_t module{-1}; ///< address - module
     Int_t layer{-1};  ///< address - layer
     Int_t sipm{-1};  ///< address - sipm
+    char side;  ///< address - side
 
     Int_t SiPMID{-1}; ///< SIPM ID
 
@@ -46,15 +47,38 @@ public:
     // methods
     /// Set SiPM ID
     /// \param sID SiPM ID
-    void setAddress(Int_t sID)
+    void setChannel(Int_t sID)
     {
         SiPMID = sID;
     }
     /// Get SiPM ID
     /// \param sID SiPM ID
-    void getAddress(Int_t& sID) const
+    void getChannel(Int_t& sID) const
     {
         sID = SiPMID;
+    }
+    // methods
+    /// Set address
+    /// \param m module
+    /// \param l layer
+    /// \param f fiber
+    void setAddress(Int_t m, Int_t l, Int_t f, char s)
+    {
+        module = m;
+        layer = l;
+        sipm = f;
+        side = s;
+    }
+    /// Get address
+    /// \param m module
+    /// \param l layer
+    /// \param f fiber
+    void getAddress(Int_t& m, Int_t& l, Int_t& f, char& s) const
+    {
+        m = module;
+        l = layer;
+        f = sipm;
+        s = side;
     }
 
     /// Set QDC value

--- a/lib/fibers/SSiPMHit.h
+++ b/lib/fibers/SSiPMHit.h
@@ -26,6 +26,10 @@ class SIFI_EXPORT SSiPMHit : public TObject
 {
 protected:
     // members
+    Int_t module{-1}; ///< address - module
+    Int_t layer{-1};  ///< address - layer
+    Int_t sipm{-1};  ///< address - sipm
+
     Int_t SiPMID{-1}; ///< SIPM ID
 
     Float_t qdc{0.};  ///< SiPM qdc value


### PR DESCRIPTION
- Commented out `SSiPMCluster` related lines, update `SiPMID` lookup. The `SSiPMCluster` related files do not currently work. It was necessary to run `sifi_dst_4to1`.
- Wasn't sure why `fakeSiPMID=SiPMID*n_fibers_per_SiPM+j;` was used. Maybe it should have been handled in the params.txt file.
- If there is an undefined TOFPET (TP) absolute channelID, the program reports it instead of failing immediately.
- Rename container to TPLookupTable, TP generated TTree is named events (it was called `data` previously` but ROOT did not play well with a TTree with the name `data`)
- Made a working early version of SSiPMHit branch filling in the SiFi SiPM address (module, layer, sipm, side) and the TP absolute channel Id.

![preliminary](https://user-images.githubusercontent.com/1140150/209989876-0cba8d11-754c-43fd-a231-716a9e25f1dc.png)

There is still some issues with the params.txt so only TP absolute ID from one board is read out.

sifi_dst_4to1 0x1000::/scratch1/gccb/data/TOFPET2/root/raw00450_single.root -e 10000 -p /scratch1/gccb/data/TOFPET2/results/sifi_params_4to1_goodmapping.txt -o output.root