### PR TITLE
Updated channel addressing

### DIFF
--- a/lib/base/datasources/STP4to1Extractor.cc
+++ b/lib/base/datasources/STP4to1Extractor.cc
@@ -132,7 +132,6 @@ bool STP4to1Extractor::write_to_tree(std::vector<std::shared_ptr<TP4to1Hit>> & h
 
     SFibersLookupTable* pLookUp;
     pLookUp = dynamic_cast<SFibersLookupTable*>(pm()->getLookupContainer("TPLookupTable"));
-    SLocator loc(3);
     int n_hits = hits.size();
     for (int i = 0; i < n_hits; i++)
     {
@@ -150,9 +149,9 @@ bool STP4to1Extractor::write_to_tree(std::vector<std::shared_ptr<TP4to1Hit>> & h
         }
         SFibersChannel* lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000,hits[i]->channelID) );
         if(!lc) {
-//            fprintf(stderr, "STP4to1Extractor TOFPET2 Ch%d missing. Check params.txt.\n", hits[i]->channelID);
+            fprintf(stderr, "STP4to1Extractor TOFPET2 absolute Ch%d missing. Check params.txt.\n", hits[i]->channelID);
         } else {
-            pHit->setChannel(hits[i]->channelID);
+            pHit->setChannel(lc->s);
             pHit->setAddress(lc->m, lc->l, lc->s, lc->side);
             pHit->setQDC(hits[i]->energy);
             pHit->setTime(hits[i]->time);

--- a/lib/base/datasources/STP4to1Extractor.cc
+++ b/lib/base/datasources/STP4to1Extractor.cc
@@ -152,7 +152,7 @@ bool STP4to1Extractor::write_to_tree(std::vector<std::shared_ptr<TP4to1Hit>> & h
             fprintf(stderr, "STP4to1Extractor TOFPET2 absolute Ch%d missing. Check params.txt.\n", hits[i]->channelID);
         } else {
             pHit->setChannel(lc->s);
-            pHit->setAddress(lc->m, lc->l, lc->s, lc->side);
+            pHit->setAddress(lc->m, lc->l, lc->element, lc->side);
             pHit->setQDC(hits[i]->energy);
             pHit->setTime(hits[i]->time);
         }

--- a/lib/base/datasources/STP4to1Extractor.h
+++ b/lib/base/datasources/STP4to1Extractor.h
@@ -37,11 +37,11 @@ struct SiPMHit
 {
     Long64_t time=-100;
     Float_t energy=-100;
-    UInt_t channelID=0;
+    Int_t channelID=0;
 
     void print() const
     {
-        printf("TOFPET 4to1: time = %lld, energy = %f, channelID = %i\n", time, energy, channelID);
+        printf("TOFPET 4to1: time = %lld, energy = %f, swSiPMID = %i\n", time, energy, channelID);
     }
 };
 

--- a/lib/base/datastruct/SLookup.cc
+++ b/lib/base/datastruct/SLookup.cc
@@ -56,7 +56,7 @@ parameters in the container and write to param file.
 uint SLookupChannel::read(const char* buffer)
 {
     uint n;
-    int cnt = sscanf(buffer, "%2" SCNu8 "%2" SCNu8 "%2" SCNu8 "%n", &m, &l, &s, &n);
+    int cnt = sscanf(buffer, "%hu" "%hu" "%hu" "%n", &m, &l, &s, &n);
     assert(cnt == 3);
     return n;
 }

--- a/lib/base/datastruct/SLookup.h
+++ b/lib/base/datastruct/SLookup.h
@@ -49,7 +49,7 @@ struct SIFI_EXPORT SLookupChannel
     virtual ~SLookupChannel() = default;
 
     ///@{
-    uint16_t m, l, s; ///< component of virtual address
+    uint8_t m, l, s; ///< component of virtual address
     ///}@
 
     virtual uint read(const char* buffer);

--- a/lib/base/datastruct/SLookup.h
+++ b/lib/base/datastruct/SLookup.h
@@ -49,7 +49,7 @@ struct SIFI_EXPORT SLookupChannel
     virtual ~SLookupChannel() = default;
 
     ///@{
-    uint8_t m, l, s; ///< component of virtual address
+    uint16_t m, l, s; ///< component of virtual address
     ///}@
 
     virtual uint read(const char* buffer);

--- a/lib/fibers/SFibersIdentification.cc
+++ b/lib/fibers/SFibersIdentification.cc
@@ -59,7 +59,6 @@ std::vector<std::shared_ptr<fibAddress>> SFibersIdentification::get4to1FiberFrom
 //seg faults when the SiPMID does not exist, check params.txt
         lc = dynamic_cast<SMultiFibersChannel*>(pLookUp->getAddress(0x1000, 55) );
         std::vector<std::vector<std::string> > vec = lc->vecFiberAssociations;
-        lc->print();
 //        std::cout << lc->m << " " << lc->l << " " << lc->s << std::endl;
 //        UInt_t fakeSiPMID = -1;
 //        

--- a/lib/fibers/SFibersLookup.cc
+++ b/lib/fibers/SFibersLookup.cc
@@ -26,7 +26,7 @@ A unpacker task.
 uint SFibersChannel::read(const char* buffer)
 {
     uint n;
-    int cnt = sscanf(buffer, "%2" SCNu8 "%2" SCNu8 "%2" SCNu8 "%*[ ]%c %n", &m, &l, &s, &side, &n);
+    int cnt = sscanf(buffer, "%3" SCNu8 "%3" SCNu8 "%3" SCNu8 "%*[ ]%c %n", &m, &l, &s, &side, &n);
     assert(cnt == 4);
     return n;
 }

--- a/lib/fibers/SFibersLookup.cc
+++ b/lib/fibers/SFibersLookup.cc
@@ -26,14 +26,14 @@ A unpacker task.
 uint SFibersChannel::read(const char* buffer)
 {
     uint n;
-    int cnt = sscanf(buffer, "%hu" "%hu" "%hu" "%*[ ]%c %n", &m, &l, &s, &side, &n);
-    assert(cnt == 4);
+    int cnt = sscanf(buffer, "%hu" "%hu" "%hu" "%hu" "%*[ ]%c %n", &m, &l, &element, &s, &side, &n);
+    assert(cnt == 5);
     return n;
 }
 
 uint SFibersChannel::write(char* buffer, size_t n) const
 {
-    uint cnt = snprintf(buffer, n, "%3d  %3d  %3d   %c", m, l, s, side);
+    uint cnt = snprintf(buffer, n, "%3d  %3d  %3d  %3d  %c", m, l, element, s, side);
     if (cnt < 0) return cnt;
     if (cnt < n) return 0;
     return cnt;
@@ -41,7 +41,7 @@ uint SFibersChannel::write(char* buffer, size_t n) const
 
 void SFibersChannel::print(bool newline, const char* prefix) const
 {
-    printf("%s %d  %d  %d  %c", prefix, m, l, s, side);
+    printf("%s %d  %d  %d %d  %c", prefix, m, l, element, s, side);
     if (newline) putchar('\n');
 }
 

--- a/lib/fibers/SFibersLookup.cc
+++ b/lib/fibers/SFibersLookup.cc
@@ -26,7 +26,7 @@ A unpacker task.
 uint SFibersChannel::read(const char* buffer)
 {
     uint n;
-    int cnt = sscanf(buffer, "%3" SCNu8 "%3" SCNu8 "%3" SCNu8 "%*[ ]%c %n", &m, &l, &s, &side, &n);
+    int cnt = sscanf(buffer, "%hu" "%hu" "%hu" "%*[ ]%c %n", &m, &l, &s, &side, &n);
     assert(cnt == 4);
     return n;
 }

--- a/lib/fibers/SFibersLookup.h
+++ b/lib/fibers/SFibersLookup.h
@@ -28,6 +28,7 @@
  */
 struct SIFI_EXPORT SFibersChannel : public SLookupChannel
 {
+    uint16_t m, l, f, element, s;
     char side; ///< side of a fiber, either 'l' or 'r'
 
     SFibersChannel() {}

--- a/lib/fibers/SSiPMHit.cc
+++ b/lib/fibers/SSiPMHit.cc
@@ -29,7 +29,7 @@ A container for Fibers Stack Raw data
  */
 void SSiPMHit::Clear(Option_t* /*opt*/)
 {
-    SiPMID = -1;
+    swSiPMID = -1;
 
     qdc = 0.0;
     time = 0;
@@ -40,6 +40,6 @@ void SSiPMHit::Clear(Option_t* /*opt*/)
  */
 void SSiPMHit::print() const
 {
-    printf("SiPM ID=%d  QDC=%f  Time=%lld\n", SiPMID,
+    printf("swSiPMID=%d  QDC=%f  Time=%lld\n", swSiPMID,
            qdc, time);
 }

--- a/lib/fibers/SSiPMHit.h
+++ b/lib/fibers/SSiPMHit.h
@@ -28,10 +28,10 @@ protected:
     // members
     Int_t module{-1}; ///< address - module
     Int_t layer{-1};  ///< address - layer
-    Int_t sipm{-1};  ///< address - sipm
+    Int_t element{-1};  ///< address - sipm
     char side;  ///< address - side
 
-    Int_t SiPMID{-1}; ///< SIPM ID
+    Int_t swSiPMID{-1}; ///< SIPM ID
 
     Float_t qdc{0.};  ///< SiPM qdc value
     Long64_t time{0}; ///< SiPM time value
@@ -49,24 +49,24 @@ public:
     /// \param sID SiPM ID
     void setChannel(Int_t sID)
     {
-        SiPMID = sID;
+        swSiPMID = sID;
     }
     /// Get SiPM ID
     /// \param sID SiPM ID
     void getChannel(Int_t& sID) const
     {
-        sID = SiPMID;
+        sID = swSiPMID;
     }
     // methods
     /// Set address
     /// \param m module
     /// \param l layer
-    /// \param f fiber
+    /// \param f element
     void setAddress(Int_t m, Int_t l, Int_t f, char s)
     {
         module = m;
         layer = l;
-        sipm = f;
+        element = f;
         side = s;
     }
     /// Get address
@@ -77,7 +77,7 @@ public:
     {
         m = module;
         l = layer;
-        f = sipm;
+        f = element;
         s = side;
     }
 


### PR DESCRIPTION
The channel addressing looks like:
```
#   FTAB id hwSiPMID    mod     layer   element   swSiPMID side l/r
0x1000       32         0       3        1           111         l
```
The branch name is updated as well to element and swSiPMID.
The variable type for m, l, element, swSiPMID is now unsigned short instead of uint8_t, a 2^8 number.

![swSiPMID](https://user-images.githubusercontent.com/1140150/210235856-a428282b-e88e-4c48-a42a-46a6207fed7c.png)
