### PR TITLE
add additional cmd line arg for setting TTree entry offset

### DIFF
--- a/dst/dst_4to1.cc
+++ b/dst/dst_4to1.cc
@@ -10,7 +10,6 @@
 #include "SFibersTP4to1Unpacker.h"
 #include "SLookup.h"
 #include "STP4to1Source.h"
-// #include "STPSource.h"
 #include "STP4to1Extractor.h"
 #include "SParAsciiSource.h"
 #include "STaskManager.h"
@@ -32,6 +31,7 @@
 
 int main(int argc, char** argv)
 {
+    int events_offset = 0;
     int events = 1000000;
     int save_samples = 0;
 
@@ -41,6 +41,7 @@ int main(int argc, char** argv)
     while (1)
     {
         static struct option long_options[] = {{"ss", no_argument, &save_samples, 1},
+                                               {"events_offset", required_argument, 0, 'i'},
                                                {"events", required_argument, 0, 'e'},
                                                {"output", required_argument, 0, 'o'},
                                                {"params_file", required_argument, 0, 'p'},
@@ -48,12 +49,15 @@ int main(int argc, char** argv)
 
         int option_index = 0;
 
-        int c = getopt_long(argc, argv, "e:o:p:", long_options, &option_index);
+        int c = getopt_long(argc, argv, "i:e:o:p:", long_options, &option_index);
 
         if (c == -1) { break; }
 
         switch (c)
         {
+            case 'i':
+                events_offset = atoi(optarg);
+                break;
             case 'e':
                 events = atoi(optarg);
                 break;
@@ -84,19 +88,19 @@ int main(int argc, char** argv)
             std::string name = inpstr.substr(pos2 + 1, inpstr.length() - pos2 - 1);
             std::string ext = name.substr(name.find_last_of(".") + 1);
             uint16_t addr = std::stoi(saddr, nullptr, 16);
-            std::cout << "addr" << addr << std::endl;
             if(ext == "root")
             {
                 SFibersTP4to1Unpacker* unp = new SFibersTP4to1Unpacker();
                 STP4to1Source* source= new STP4to1Source(addr);
-                source->addUnpacker(unp, {addr});
+                source->addUnpacker(unp, {addr});                
                 source->setInput(name);
+                source->setEntriesOffset(events_offset);
                 sifi()->addSource(source);
             }
             else
             {
-                std::cerr << "##### Error in dst: unknown data file extension!" << std::endl;
-                std::cerr << "Acceptable extensions: *.root" << std::endl;
+                std::cerr << "##### Error in dst_4to1: unknown data file extension!" << std::endl;
+                std::cerr << "Acceptable extensions: *.root (TOFPET2 DAQ singles ROOT TTree)" << std::endl;
                 std::cerr << "Given data file: " << name << std::endl;
                 std::exit(EXIT_FAILURE);
             }

--- a/lib/base/datasources/STP4to1Source.cc
+++ b/lib/base/datasources/STP4to1Source.cc
@@ -89,10 +89,6 @@ bool STP4to1Source::readCurrentEvent()
     const double ps_to_ns = 1E3;
     std::vector<std::shared_ptr<TP4to1Hit>> hits;
     
-//    SFibersLookupTable* pLookUp;
-//    pLookUp = dynamic_cast<SFibersLookupTable*>(pm()->getLookupContainer("TPLookupTable"));
-//    SLocator loc(3);
-
     if (state == DONE) { return false; }
 
     if (state == INIT)
@@ -102,7 +98,7 @@ bool STP4to1Source::readCurrentEvent()
         t->SetBranchAddress("time",&(hit_cache->time));
         t->SetBranchAddress("channelID",&(hit_cache->channelID));
         t->SetBranchAddress("energy",&(hit_cache->energy));
-        t->GetEntry(entries_counter);
+        t->GetEntry(entries_offset + entries_counter);
         entries_counter++;
         if(entries_counter == nentries) state = DONE;
         hit_cache->time /= ps_to_ns;
@@ -127,7 +123,7 @@ bool STP4to1Source::readCurrentEvent()
                 state = DONE;
                 break;
             }
-            t->GetEntry(entries_counter);
+            t->GetEntry(entries_offset + entries_counter);
             hit_current->time /= ps_to_ns;
             double current_time = hit_current->time;
 
@@ -139,7 +135,6 @@ bool STP4to1Source::readCurrentEvent()
             else // next event
             {
                 hit_cache = hit_current;
-//                 std::cout << std::endl;
                 break;
             }
         }

--- a/lib/base/datasources/STP4to1Source.h
+++ b/lib/base/datasources/STP4to1Source.h
@@ -38,7 +38,7 @@ struct TP4to1Hit
 
     void print() const
     {
-        printf("TOFPET 4to1: time = %lld, energy = %f, channelID = %i\n", time, energy, channelID);
+        printf("TOFPET 4to1: time = %lld, energy = %f, hwSiPMID = %i\n", time, energy, channelID);
     }
 };
 
@@ -55,15 +55,16 @@ public:
     virtual bool close() override;
     virtual bool readCurrentEvent() override;
     virtual void setInput(const std::string& filename, size_t length = 0);
+    void setEntriesOffset(Long64_t i) { entries_offset = i; };
 
 private:
     uint16_t subevent;     ///< subevent id
     std::string input;     ///< source file name
     TFile * input_file;    ///< data input file
-    TTree *t;
+    TTree *t;              ///< TOFPET2 DAQ generated singles TTree
     Long64_t nentries;
     std::shared_ptr<TP4to1Hit> hit_cache;
-    Long64_t entries_counter;
+    Long64_t entries_offset, entries_counter;
     SCategory* catSiPMHit;
     STP4to1Extractor * extractor;
     enum State

--- a/lib/fibers/SMultiFibersLookup.cc
+++ b/lib/fibers/SMultiFibersLookup.cc
@@ -54,12 +54,9 @@ uint SMultiFibersChannel::read(const char* buffer)
     for(int i=0; i < segment.size(); ++i) {
             std::vector<std::string> token;
             tokenize(segment[i], token, ',');
-            if(token.size() == 4) {
-                if(token[0]!="" && token[1]!="" && token[2]!="" && token[3]!="") {
-                    vecFiberAssociations.push_back(token);
-                }
-            } else {
-                fprintf(stderr, "SMultiFibersChannel: There is a problem with your addressing. Check params.txt.\n");
+            if(segment[i].find(",,,") == std::string::npos) continue;
+            if(token[0]!="" && token[1]!="" && token[2]!="" && token[3]!="") {
+                vecFiberAssociations.push_back(token);
             }
     }
     return 0; //unused, just for backwards compatibility


### PR DESCRIPTION
The command to process TOFPET singles ROOT TTrees to sifi-framework can now define a start entry number with the optarg i. For example:
```
sifi_dst_4to1 0x1000::/scratch1/gccb/data/TOFPET2/root/raw00449_single.root -i 3 -e 3 -p params.txt -o output.root
```