### PR TITLE
Sipm clustering

### DIFF
--- a/lib/base/datastruct/SCategory.h
+++ b/lib/base/datastruct/SCategory.h
@@ -57,7 +57,7 @@ public:
         CatSiPMHit,        ///< SiPM hits raw data (4 to 1 coupling)
                            // tracks
                            // Limit
-//        CatSiPMClus,       ///< SiPM clusters
+        CatSiPMClus,       ///< SiPM clusters
         CatLimitDoNotUse,  ///< holds size of the category list
         CatNone,           ///< Clear category list in SLoop
     };

--- a/lib/base/util/SLoop.cc
+++ b/lib/base/util/SLoop.cc
@@ -102,7 +102,6 @@ bool SLoop::addFiles(const std::vector<std::string>& files)
  */
 void SLoop::setInput(std::initializer_list<SCategory::Cat> categories)
 {
-    std::cout << "MARK <<<<<<<<<<<<<<" << std::endl;
     if (chain->GetListOfFiles()->GetEntries() == 0) abort();
 
     current_event = 0;

--- a/lib/base/util/SLoop.cc
+++ b/lib/base/util/SLoop.cc
@@ -102,6 +102,7 @@ bool SLoop::addFiles(const std::vector<std::string>& files)
  */
 void SLoop::setInput(std::initializer_list<SCategory::Cat> categories)
 {
+    std::cout << "MARK <<<<<<<<<<<<<<" << std::endl;
     if (chain->GetListOfFiles()->GetEntries() == 0) abort();
 
     current_event = 0;

--- a/lib/fibers/CMakeLists.txt
+++ b/lib/fibers/CMakeLists.txt
@@ -34,9 +34,9 @@ SIFI_GENERATE_LIBRARY(
         SFibersClusterFinderPar.cc
         SFibersCluster.cc
         SFibersIdentification.cc
-        #        SSiPMCluster.cc
+        SSiPMCluster.cc
         #        SSiPMLookup.cc
-        #        SSiPMClusterFinder.cc
+        SSiPMClusterFinder.cc
     HEADERS
         SFibersDetector.h
         SFibersGeomPar.h
@@ -69,9 +69,9 @@ SIFI_GENERATE_LIBRARY(
         SFibersClusterFinderPar.h
         SFibersCluster.h
         SFibersIdentification.h
-        #        SSiPMCluster.h
+        SSiPMCluster.h
         #        SSiPMLookup.h
-        #        SSiPMClusterFinder.h
+        SSiPMClusterFinder.h
 
     PRIVATE_LIBRARIES
         ROOT::Core

--- a/lib/fibers/Linkdef.h
+++ b/lib/fibers/Linkdef.h
@@ -20,7 +20,7 @@
 #pragma link C++ class SFibersHit+;
 #pragma link C++ class SFibersHitSim+;
 #pragma link C++ class SFibersCluster+;
-//#pragma link C++ class SSiPMCluster+;
+#pragma link C++ class SSiPMCluster+;
 
 // clang-format on
 

--- a/lib/fibers/SFibersDetector.cc
+++ b/lib/fibers/SFibersDetector.cc
@@ -80,7 +80,7 @@ bool SFibersDetector::initTasks()
     else
     {
         addTask(new SFibersUnpacker(), 0);
-//        addTask(new SSiPMClusterFinder(), 1);
+        addTask(new SSiPMClusterFinder(), 1);
         addTask(new SFibersCalibrator(), 1);
         addTask(new SFibersHitFinder(), 2);
         addTask(new SFibersClusterFinder(), 3);
@@ -143,8 +143,8 @@ bool SFibersDetector::initCategories()
     size_t sizes_SiPM[1];
     sizes_SiPM[0] = modules*layers*fibers;
     
-//    size_t size_SiPM_cluster[1];
-//    size_SiPM_cluster[0] = 20;
+    size_t size_SiPM_cluster[1];
+    size_SiPM_cluster[0] = 20;
 
     if (isSimulation())
     {
@@ -163,8 +163,8 @@ bool SFibersDetector::initCategories()
             return false;
         if (!dm->registerCategory(SCategory::CatSiPMHit, "SSiPMHit", 1, sizes_SiPM, false))
             return false;
-//        if (!dm->registerCategory(SCategory::CatSiPMClus, "SSiPMCluster", 1, size_SiPM_cluster, false))
-//            return false;
+        if (!dm->registerCategory(SCategory::CatSiPMClus, "SSiPMCluster", 1, size_SiPM_cluster, false))
+            return false;
         if (!dm->registerCategory(SCategory::CatFibersCal, "SFibersCal", 3, sizes, false))
             return false;
         if (!dm->registerCategory(SCategory::CatFibersHit, "SFibersHit", 3, sizes, false))

--- a/lib/fibers/SSiPMCluster.cc
+++ b/lib/fibers/SSiPMCluster.cc
@@ -24,14 +24,14 @@
 void SSiPMCluster::Clear(Option_t* opt)
 {
     point.Clear();
-    errors.Clear();
+//    errors.Clear();
     hits.clear();
 }
 
 void SSiPMCluster::print() const
 {
-    printf("SiPM CLUSTER:  module = %d  cluster = %d  x,y,z = (%f, %f, %f) +/- (%f, %f, %f)\n",
-           module, cluster, point.x(), point.y(), point.z(), errors.x(), errors.y(), errors.z());
+//    printf("SiPM CLUSTER:  module = %d  cluster = %d  x,y,z = (%f, %f, %f) +/- (%f, %f, %f)\n",
+//           module, cluster, point.x(), point.y(), point.z(), errors.x(), errors.y(), errors.z());
     
     printf("SiPM HITS:");
     

--- a/lib/fibers/SSiPMCluster.cc
+++ b/lib/fibers/SSiPMCluster.cc
@@ -10,7 +10,7 @@
  *************************************************************************/
  
 #include "SSiPMCluster.h"
-
+#include "SSiPMHit.h"
 #include <cstdio>
 
 /**
@@ -33,10 +33,21 @@ void SSiPMCluster::print() const
 //    printf("SiPM CLUSTER:  module = %d  cluster = %d  x,y,z = (%f, %f, %f) +/- (%f, %f, %f)\n",
 //           module, cluster, point.x(), point.y(), point.z(), errors.x(), errors.y(), errors.z());
     
-    printf("SiPM HITS:");
+    printf("SiPM CLUSTER: cluster = %d num of hits = %d x,y,z = (%f, %f, %f)\n", cluster, hits.size(), point.x(), point.y(), point.z());
+    printf("SiPM HITS:\n");
     
-    for(auto & h : hits)
-        printf(" %d", h);
+    for(auto & h : hits) {
+//        printf(" %d", h);
+        SSiPMHit* pHit = dynamic_cast<SSiPMHit*>(catSiPMsHit->getObject(h));
+        if (!pHit)
+        {
+            printf("SiPMHit %d doesn't exists!\n", h);
+            continue;
+        }
+        pHit->print();
+    }
     
     printf("\n");
+
+
 }

--- a/lib/fibers/SSiPMCluster.h
+++ b/lib/fibers/SSiPMCluster.h
@@ -22,12 +22,12 @@
 #include <algorithm>
 #include <vector>
 
+#include <SCategory.h>
 class SIFI_EXPORT SSiPMCluster : public TObject
 {
-    
 protected: 
 //    Int_t module{-1};  ///< address - module
-//    Int_t cluster{-1}; ///< address - cluster ID
+    Int_t cluster{-1}; ///< address - cluster ID
     
     TVector3 point;  ///< cluster position
 //    TVector3 errors; ///< cluster position errors
@@ -35,6 +35,8 @@ protected:
     std::vector<Int_t> hits; ///< list of hits belonging to the cluster
     
 public:
+
+    SCategory * catSiPMsHit;
     
     /// Default constructor
     SSiPMCluster() = default;
@@ -48,17 +50,17 @@ public:
     /// Setting the cluster address
     /// \param m - module
     /// \param c - cluster
-    void setAddress(Int_t m, Int_t c)
+    void setAddress(Int_t c)
     {
 //        module = m;
-//        cluster = c;
+        cluster = c;
     }
     
     /// Getting the cluster address
-    void getAddress(Int_t &m, Int_t &c) const
+    void getAddress(Int_t &c) const
     {
 //        m = module;
-//        c = cluster;
+        c = cluster;
     }
     
     /// Add SiPM hit to the cluster

--- a/lib/fibers/SSiPMCluster.h
+++ b/lib/fibers/SSiPMCluster.h
@@ -26,11 +26,11 @@ class SIFI_EXPORT SSiPMCluster : public TObject
 {
     
 protected: 
-    Int_t module{-1};  ///< address - module
-    Int_t cluster{-1}; ///< address - cluster ID
+//    Int_t module{-1};  ///< address - module
+//    Int_t cluster{-1}; ///< address - cluster ID
     
     TVector3 point;  ///< cluster position
-    TVector3 errors; ///< cluster position errors
+//    TVector3 errors; ///< cluster position errors
     
     std::vector<Int_t> hits; ///< list of hits belonging to the cluster
     
@@ -50,15 +50,15 @@ public:
     /// \param c - cluster
     void setAddress(Int_t m, Int_t c)
     {
-        module = m;
-        cluster = c;
+//        module = m;
+//        cluster = c;
     }
     
     /// Getting the cluster address
     void getAddress(Int_t &m, Int_t &c) const
     {
-        m = module;
-        c = cluster;
+//        m = module;
+//        c = cluster;
     }
     
     /// Add SiPM hit to the cluster
@@ -92,13 +92,13 @@ public:
     /// \return errors of the cluster position
     TVector3 & getErrors()
     {
-        return errors;
+//        return errors;
     }
     
     /// \copydoc getErrors()
     const TVector3 & getErrors() const
     {
-        return errors;
+//        return errors;
     }
     
     /// Printing details of the object.

--- a/lib/fibers/SSiPMClusterFinder.cc
+++ b/lib/fibers/SSiPMClusterFinder.cc
@@ -42,7 +42,7 @@
 
 bool SSiPMClusterFinder::init()
 {
-    catSiPMsHit = sifi()->getCategory(SCategory::CatSiPMHit);
+    catSiPMsHit = sifi()->buildCategory(SCategory::CatSiPMHit);
     
     if(!catSiPMsHit)
     {
@@ -50,7 +50,7 @@ bool SSiPMClusterFinder::init()
         return false;
     }
     
-   catSiPMsCluster = sifi()->getCategory(SCategory::CatSiPMClus);
+   catSiPMsCluster = sifi()->buildCategory(SCategory::CatSiPMClus);
    
    if(!catSiPMsCluster)
    {
@@ -70,8 +70,26 @@ bool checkIfNeighbours(SSiPMHit* hit_1, SSiPMHit* hit_2)
 bool SSiPMClusterFinder::execute()
 {
     
-    /// TODO creating clusters
-    
+    int size = catSiPMsHit->getEntries();
+    for (int i = 0; i < size; ++i)
+    {
+        SSiPMHit* pHit = dynamic_cast<SSiPMHit*>(catSiPMsHit->getObject(i));
+        if (!pHit)
+        {
+            printf("SiPMHit doesn't exists!\n");
+            continue;
+        }
+        Int_t mod = 0;
+        Int_t lay = 0;
+        Int_t element = 0;
+        char side = '\0';
+        pHit->getAddress(mod, lay, element, side);
+
+        Float_t qdc = pHit->getQDC();
+        Long64_t time = pHit->getTime();
+        // checkIfNeighbours() somehow?
+        // then construct SSiPMCluster and addHit() and point(0, 0, 0)
+    }    
     return true;
 }
 

--- a/lib/fibers/SSiPMClusterFinder.cc
+++ b/lib/fibers/SSiPMClusterFinder.cc
@@ -69,6 +69,10 @@ bool checkIfNeighbours(SSiPMHit* hit_1, SSiPMHit* hit_2)
 
 bool SSiPMClusterFinder::execute()
 {
+/////
+        std::vector<std::vector<UInt_t>> SiPMadresses;
+        std::vector<UInt_t> ja;
+/////
     
     int size = catSiPMsHit->getEntries();
     for (int i = 0; i < size; ++i)
@@ -85,11 +89,125 @@ bool SSiPMClusterFinder::execute()
         char side = '\0';
         pHit->getAddress(mod, lay, element, side);
 
-        Float_t qdc = pHit->getQDC();
-        Long64_t time = pHit->getTime();
-        // checkIfNeighbours() somehow?
-        // then construct SSiPMCluster and addHit() and point(0, 0, 0)
+/////
+        ja.push_back(i);
+        ja.push_back(mod);
+        ja.push_back(lay);
+        ja.push_back(element);
+
+
+        if(side=='r'){
+            ja.push_back(0);
+
+        }
+        if(side=='l'){
+            ja.push_back(1);
+
+        }
+        SiPMadresses.push_back(ja);
+        ja.clear();
+/////
     }    
+/////
+
+ // algorithm for clustering- ugly version          
+           std::vector<std::vector<UInt_t>> cluster;
+           std::vector<UInt_t> cl;
+           int not_cluster=1;
+           std::vector<std::vector<std::vector<UInt_t>>> clusters;
+           std::vector<std::vector<UInt_t>> candidates;
+           int cluster_size;
+           for(int i=0; i<SiPMadresses.size();i++)
+                {
+                    candidates.push_back(SiPMadresses[i]);
+                }
+            while(not_cluster){
+                not_cluster=0;
+                cluster.clear();
+                if(!SiPMadresses.empty()){
+                    cl.push_back(SiPMadresses[0][0]);
+                    cl.push_back(SiPMadresses[0][1]);
+                    cl.push_back(SiPMadresses[0][2]);
+                    cl.push_back(SiPMadresses[0][3]);
+                    cl.push_back(SiPMadresses[0][4]);
+                    cluster.push_back(cl);
+                    SiPMadresses.erase(SiPMadresses.begin());
+                    candidates.erase(candidates.begin());
+                
+                for(int i=0; i<SiPMadresses.size();i++)
+                {
+                    cluster_size=cluster.size();
+                    for(std::vector<UInt_t> j : cluster)
+                    {
+                        cl.clear();
+                        if (j[1]==SiPMadresses[i][1] and j[4]==SiPMadresses[i][4] and abs((int)(j[2]-SiPMadresses[i][2]) )<=1 and abs((int)(j[3]-SiPMadresses[i][3]) )<=1)
+                        {
+                            cl.push_back(SiPMadresses[i][0]);
+                            cl.push_back(SiPMadresses[i][1]);
+                            cl.push_back(SiPMadresses[i][2]);
+                            cl.push_back(SiPMadresses[i][3]);
+                            cl.push_back(SiPMadresses[i][4]);
+                            cluster.push_back(cl);
+                            candidates.erase(candidates.begin()+i);
+                            break;
+                        }
+                    }
+                    if(cluster_size==cluster.size())
+                        {
+                            not_cluster=not_cluster+1;
+                        }
+                    }    
+                }
+                clusters.push_back(cluster); 
+                SiPMadresses=candidates;
+            }
+// clusters_final is vector of vector of event's idx 
+        std::vector<std::vector<Int_t>> clusters_final;
+        std::vector<Int_t> cl_f;
+        for(int i=0; i<clusters.size(); i++)
+        {
+            cl_f.clear();
+            for(int j=0;j<clusters[i].size();j++){
+                cl_f.push_back(clusters[i][j][0]);
+            }
+        clusters_final.push_back(cl_f);
+        }
+        
+//    
+//    //change the code below by inserting the fiber identification algorithm and based on the algorithm, fill the allFibData structure for all subevents
+//    int n_subevents = 5; //number of subevents
+//    for (int i = 0; i < n_subevents; i++)
+//    {
+//        fibData->energyL=0.0;
+//        fibData->timeL=0.0;
+//        fibData->energyR=0.0;
+//        fibData->timeR=0.0;
+//        fibData->mod=0;
+//        fibData->lay=0;
+//        fibData->fi=0;
+//        allFibData.push_back(fibData);
+//    }
+             SiPMadresses.clear();
+/////
+        for(Int_t i=0; i < clusters_final.size(); ++i) {
+            SLocator loc(1);
+            loc[0] = i;
+            SSiPMCluster* pClus = dynamic_cast<SSiPMCluster*>(catSiPMsCluster->getObject(loc));
+            if (!pClus)
+            {
+                pClus = reinterpret_cast<SSiPMCluster*>(catSiPMsCluster->getSlot(loc));
+                pClus = new (pClus) SSiPMCluster;
+                pClus->Clear();
+            }
+            pClus->setAddress(i);
+            for(Int_t j=0; j < clusters_final[i].size(); ++j) {
+                pClus->addHit(clusters_final[i][j]);
+                pClus->getPoint().SetXYZ(0, 0, 0);
+                pClus->catSiPMsHit = catSiPMsHit;
+            }
+            pClus->print();
+        }
+
     return true;
 }
 

--- a/lib/fibers/SSiPMClusterFinder.cc
+++ b/lib/fibers/SSiPMClusterFinder.cc
@@ -12,8 +12,6 @@
 #include "SSiPMClusterFinder.h"
 #include "SSiPMCluster.h"
 #include "SCategory.h"
-#include "SFibersGeomPar.h"
-#include "SSiPMLookup.h"
 #include "SSiPMHit.h"
 #include "SLocator.h"
 #include "SPar.h"
@@ -52,104 +50,27 @@ bool SSiPMClusterFinder::init()
         return false;
     }
     
-//    catSiPMsCluster = sifi()->getCategory(SCategory::CatSiPMClus);
-//    
-//    if(!catSiPMsCluster)
-//    {
-//        std::cerr << "No CatSiPMClus category!" << std::endl;
-//    }
-    
-    pLookup = dynamic_cast<SSiPMLookupTable*>(pm()->getLookupContainer("SiPMLookupTable")); // TODO transfer this to STP4to1source?
-    
-    if(!pLookup)
-    {
-        std::cerr << "No lookup table SiPMLookupTable!" << std::endl;
-        return false;
-    }
+   catSiPMsCluster = sifi()->getCategory(SCategory::CatSiPMClus);
+   
+   if(!catSiPMsCluster)
+   {
+       std::cerr << "No CatSiPMClus category!" << std::endl;
+   }
     
     return true;
 }
 
 bool checkIfNeighbours(SSiPMHit* hit_1, SSiPMHit* hit_2)
 {
-    
+ 
+    /// TODO checking if two given sipms are neighbours
     
 }
 
 bool SSiPMClusterFinder::execute()
 {
-    // getting geometry
-    const size_t n_modules = pLookup->getModules();
-    size_t n_layers[n_modules];
-    size_t n_sipms_per_layer[n_modules];
     
-    for(int i=0; i<n_modules; ++i)
-    {
-        n_layers[i] = pLookup->getLayers(i);
-        n_sipms_per_layer[i] = pLookup->getSiPMsPerLayer(i, 0);
-    }
-    
-    // temporary structure representing SiPM cluster
-    struct tmp_cluster
-    {
-        int id{-1};
-        TVector3 position;
-        TVector3 error;
-        std::vector<SSiPMHit*> hits;
-    };
-     
-    // vector of all clusters in the analyzed event
-    std::vector<tmp_cluster> clusters;
-    
-    // map of hits indicating which of hits belong to a cluster; int = -1 (no cluster assigned), int >= 0 (cluster id)
-    std::map<SSiPMHit*, int> hit_cluster_map;
-    
-    int n_entries = catSiPMsHit->getEntries();
-    
-    // filling map of hits and assigning -1 to all hits
-    for (int i = 0; i< n_entries; ++i)
-    {
-        SSiPMHit* pHit = dynamic_cast<SSiPMHit*>(catSiPMsHit->getObject(i));
-        
-        if(!pHit)
-        {
-            printf("SiPM hit doesn't exist!\n");
-            continue;
-        }
-        
-        hit_cluster_map[pHit] = -1;
-    }
-    
-    // assigning hits to clusters
-    int cluster_id = -1;
-    int unassigned = hit_cluster_map.size();
-    
-    for (auto h = hit_cluster_map.begin(); h != hit_cluster_map.end(); ++h)
-    {
-        // if hit doesn't belong to any cluster, create one
-        if (h->second == -1)
-        {
-            h->second = ++cluster_id;
-            
-            tmp_cluster cl;
-            cl.id = cluster_id;
-            cl.hits.push_back(h->first);
-            
-            clusters.push_back(cl);
-            
-            --unassigned;
-        }
-        else
-            continue;
-        
-        // loop over remaining hits and try to assign them, repeat as many times as not assigned hits remains.
-        // If touching SiPMs found aasign them to the same cluster and continue.
-        
-        for (int i = 0; i < unassigned; ++i)
-        {
-            
-        }
-    }
+    /// TODO creating clusters
     
     return true;
 }

--- a/lib/fibers/SSiPMClusterFinder.h
+++ b/lib/fibers/SSiPMClusterFinder.h
@@ -15,7 +15,6 @@
 #include "STask.h"
 
 class SCategory;
-class SSiPMLookupTable;
 
 class SSiPMClusterFinder : public STask
 {
@@ -23,7 +22,6 @@ class SSiPMClusterFinder : public STask
 protected:
     SCategory* catSiPMsHit{nullptr};      ///< category containing SiPMs hits
     SCategory* catSiPMsCluster{nullptr};  ///< category containing SiPMs clusters
-    SSiPMLookupTable* pLookup;            ///< Lookup table for SiPMs
     
 public:
     /// Default constructor

--- a/lib/fibers/SSiPMHit.cc
+++ b/lib/fibers/SSiPMHit.cc
@@ -40,6 +40,5 @@ void SSiPMHit::Clear(Option_t* /*opt*/)
  */
 void SSiPMHit::print() const
 {
-    printf("swSiPMID=%d  QDC=%f  Time=%lld\n", swSiPMID,
-           qdc, time);
+    printf("module=%d layer=%d element=%d swSiPMID=%d  side=%c QDC=%f  Time=%lld\n", module, layer, element, swSiPMID, side, qdc, time);
 }

--- a/lib/fibers/SSiPMHit.h
+++ b/lib/fibers/SSiPMHit.h
@@ -35,6 +35,8 @@ protected:
 
     Float_t qdc{0.};  ///< SiPM qdc value
     Long64_t time{0}; ///< SiPM time value
+    
+    Int_t hitID{-1}; ///< hit ID
 
 public:
     // constructor


### PR DESCRIPTION
This is an early working implementation of the SiPM cluster finder. A printout looks like:
```
SiPM CLUSTER: cluster = 0 num of hits = 2 x,y,z = (0.000000, 0.000000, 0.000000)
SiPM HITS:
module=0 layer=1 element=6 swSiPMID=34  side=l QDC=3.774082  Time=661808348
module=0 layer=1 element=5 swSiPMID=33  side=l QDC=26.225914  Time=661808347

SiPM CLUSTER: cluster = 1 num of hits = 1 x,y,z = (0.000000, 0.000000, 0.000000)
SiPM HITS:
module=0 layer=1 element=6 swSiPMID=402  side=r QDC=1.443077  Time=661808352

SiPM CLUSTER: cluster = 0 num of hits = 4 x,y,z = (0.000000, 0.000000, 0.000000)
SiPM HITS:
module=0 layer=0 element=2 swSiPMID=2  side=l QDC=34.289978  Time=661811102
module=0 layer=0 element=3 swSiPMID=3  side=l QDC=10.838291  Time=661811103
module=0 layer=1 element=2 swSiPMID=30  side=l QDC=0.615154  Time=661811108
module=0 layer=1 element=3 swSiPMID=31  side=l QDC=2.581482  Time=661811106
```
The SSiPMCluster branch is also filled.