### PR TITLE
Fix calibration lookup

### DIFF
--- a/dst/dst_4to1.cc
+++ b/dst/dst_4to1.cc
@@ -129,11 +129,11 @@ int main(int argc, char** argv)
     // initialize detectors
     SDetectorManager* detm = SDetectorManager::instance();
 
-    // As of 08.01.2023 the detector has 8 fiber layers, 56 fibers per layer.
+    // As of 08.01.2023 the detector has 7 fiber layers, 55 fibers per layer.
     // The size of the SCategory must exceed module*layer*fibers. If not it will produce
     // a segmentation fault when running registerCategory.
     // The numbers here are also not read from the params.txt file.
-    detm->addDetector(new SFibersDetector("Fibers", 1, 8, 56));
+    detm->addDetector(new SFibersDetector("Fibers", 1, 7, 55));
 
     detm->initTasks();
     detm->initParameterContainers();

--- a/dst/dst_4to1.cc
+++ b/dst/dst_4to1.cc
@@ -129,7 +129,7 @@ int main(int argc, char** argv)
     // initialize detectors
     SDetectorManager* detm = SDetectorManager::instance();
 
-    detm->addDetector(new SFibersDetector("Fibers", 4, 4, 16));
+    detm->addDetector(new SFibersDetector("Fibers", 2, 8, 28));
 
     detm->initTasks();
     detm->initParameterContainers();

--- a/dst/dst_4to1.cc
+++ b/dst/dst_4to1.cc
@@ -129,7 +129,11 @@ int main(int argc, char** argv)
     // initialize detectors
     SDetectorManager* detm = SDetectorManager::instance();
 
-    detm->addDetector(new SFibersDetector("Fibers", 2, 8, 28));
+    // As of 08.01.2023 the detector has 8 fiber layers, 56 fibers per layer.
+    // The size of the SCategory must exceed module*layer*fibers. If not it will produce
+    // a segmentation fault when running registerCategory.
+    // The numbers here are also not read from the params.txt file.
+    detm->addDetector(new SFibersDetector("Fibers", 1, 8, 56));
 
     detm->initTasks();
     detm->initParameterContainers();

--- a/dst/dst_4to1.cc
+++ b/dst/dst_4to1.cc
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
     detm->initParameterContainers();
     detm->initCategories();
 
-    pm()->addLookupContainer("TPLookupTable", std::make_unique<SFibersLookupTable>("TPLookupTable", 0x1000, 0x1fff, 20000));
+    pm()->addLookupContainer("TPLookupTable", std::make_unique<SSiPMsLookupTable>("TPLookupTable", 0x1000, 0x1fff, 20000));
     pm()->addLookupContainer("4to1SiPMtoFibersLookupTable", std::make_unique<SMultiFibersLookupTable>("4to1SiPMtoFibersLookupTable", 0x1000, 0x1fff, 20000));
     
     // initialize tasks

--- a/lib/base/datasources/STP4to1Extractor.cc
+++ b/lib/base/datasources/STP4to1Extractor.cc
@@ -130,8 +130,8 @@ bool STP4to1Extractor::write_to_tree(std::vector<std::shared_ptr<TP4to1Hit>> & h
         return false;
     }
 
-    SFibersLookupTable* pLookUp;
-    pLookUp = dynamic_cast<SFibersLookupTable*>(pm()->getLookupContainer("TPLookupTable"));
+    SSiPMsLookupTable* pLookUp;
+    pLookUp = dynamic_cast<SSiPMsLookupTable*>(pm()->getLookupContainer("TPLookupTable"));
     int n_hits = hits.size();
     for (int i = 0; i < n_hits; i++)
     {
@@ -147,7 +147,7 @@ bool STP4to1Extractor::write_to_tree(std::vector<std::shared_ptr<TP4to1Hit>> & h
                 std::cerr << "Error in STP4to1Extractor.cc: no pHit category!" << std::endl;
             }
         }
-        SFibersChannel* lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000,hits[i]->channelID) );
+        SSiPMsChannel* lc = dynamic_cast<SSiPMsChannel*>(pLookUp->getAddress(0x1000,hits[i]->channelID) );
         if(!lc) {
             fprintf(stderr, "STP4to1Extractor TOFPET2 absolute Ch%d missing. Check params.txt.\n", hits[i]->channelID);
         } else {

--- a/lib/base/datasources/STP4to1Extractor.h
+++ b/lib/base/datasources/STP4to1Extractor.h
@@ -31,7 +31,7 @@
 
 class SUnpacker;
 class SCategory;
-class SFibersLookupTable;
+class SSiPMsLookupTable;
 class SFibersIdentification;
 struct SiPMHit
 {

--- a/lib/fibers/SFibersCalibrator.cc
+++ b/lib/fibers/SFibersCalibrator.cc
@@ -121,10 +121,10 @@ bool SFibersCalibrator::execute()
         if (!_cp_l or !_cp_r)
         {
             if (!_cp_l)
-                printf("Calibration parametes for ml,f,s = %d,%d,%d,%c does not exists\n", mod, lay,
+                printf("Calibration parameters for m,l,f,s = %d,%d,%d,%c does not exists\n", mod, lay,
                        fib, 'l');
             if (!_cp_r)
-                printf("Calibration parametes for ml,f,s = %d,%d,%d,%c does not exists\n", mod, lay,
+                printf("Calibration parameters for m,l,f,s = %d,%d,%d,%c does not exists\n", mod, lay,
                        fib, 'r');
             abort();
         }
@@ -152,10 +152,6 @@ bool SFibersCalibrator::execute()
                            (cp_l[3] * (pow(e, 2) - (cp_l[1] * cp_l[2])));
         Float_t energy_r = -(e * (-e * qdc_r + (cp_r[3] * qdc_l * cp_r[2]))) /
                            (cp_r[3] * (pow(e, 2) - (cp_r[1] * cp_r[2])));
-
-//TODO MARK: temporarily not using this so the timestamp can be propagated from raw to hit
-//        time_l += cp_l[5];
-//        time_r += cp_r[5];
 
         SLocator loc(3);
         loc[0] = mod;

--- a/lib/fibers/SFibersIdentification.cc
+++ b/lib/fibers/SFibersIdentification.cc
@@ -71,14 +71,13 @@ std::vector<std::shared_ptr<identifiedFiberData>> SFibersIdentification::identif
        std::vector<std::vector<UInt_t>> SiPMadresses;
        std::vector<UInt_t> ja;
  
-        SFibersChannel* lc;
-        SFibersLookupTable* pLookUp;
-        pLookUp = dynamic_cast<SFibersLookupTable*>(pm()->getLookupContainer("TPLookupTable"));
+        SSiPMsChannel* lc;
+        SSiPMsLookupTable* pLookUp = dynamic_cast<SSiPMsLookupTable*>(pm()->getLookupContainer("TPLookupTable"));
 
         for(int j = 0; j <n_hits; j++)
         {
 
-                lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000,hits[j]->channelID ));
+                lc = dynamic_cast<SSiPMsChannel*>(pLookUp->getAddress(0x1000,hits[j]->channelID ));
 
                 
                 ja.push_back(j);
@@ -202,7 +201,7 @@ std::vector<std::shared_ptr<identifiedFiberData>> SFibersIdentification::identif
         std::vector<std::vector<UInt_t>> ab_top;
         
         for(int i=0; i<clusters_final.size(); i++){
-            lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000,hits[clusters_final[i][0]]->channelID ));
+            lc = dynamic_cast<SSiPMsChannel*>(pLookUp->getAddress(0x1000,hits[clusters_final[i][0]]->channelID ));
             if(lc->m==0 and lc->side=='l'){
                 scat_bottom.push_back(clusters_final[i]);
             }
@@ -229,7 +228,7 @@ std::vector<std::shared_ptr<identifiedFiberData>> SFibersIdentification::identif
         if (scat_bottom.size()){
         for(int i=0; i<scat_bottom.size(); i++){
             for(int j : scat_bottom[i]){
-                lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000,hits[j]->channelID));    
+                lc = dynamic_cast<SSiPMsChannel*>(pLookUp->getAddress(0x1000,hits[j]->channelID));    
                 //lc2= dynamic_cast<SMultiFibersChannel*>(pLookUp->getAddress(0x1000,lc->s));
                 lc2= dynamic_cast<SMultiFibersChannel*>(pLookUp2->getAddress(0x1000, lc->s));
                 vec = lc2->vecFiberAssociations;
@@ -246,7 +245,7 @@ std::vector<std::shared_ptr<identifiedFiberData>> SFibersIdentification::identif
         
         for(int i=0; i<scat_top.size(); i++){
             for(int j : scat_top[i]){
-                lc = dynamic_cast<SFibersChannel*>(pLookUp->getAddress(0x1000,hits[j]->channelID));    
+                lc = dynamic_cast<SSiPMsChannel*>(pLookUp->getAddress(0x1000,hits[j]->channelID));    
                 lc2= dynamic_cast<SMultiFibersChannel*>(pLookUp2->getAddress(0x1000, lc->s));
                 vec = lc2->vecFiberAssociations;
                 for(std::vector<std::string> k:vec){

--- a/lib/fibers/SFibersIdentification.cc
+++ b/lib/fibers/SFibersIdentification.cc
@@ -258,7 +258,6 @@ std::vector<std::shared_ptr<identifiedFiberData>> SFibersIdentification::identif
 
         std::vector<std::vector<std::string>> in_fiber;
         std::vector<std::vector<std::vector<std::string>>> cluster_in_fibers;
-        std::cout<<"New event"<<std::endl;
         if(cluster_fibers_sb.size() and cluster_fibers_st.size()){
         for(int i=0;i<cluster_fibers_sb.size();i++)
         {

--- a/lib/fibers/SFibersIdentification.cc
+++ b/lib/fibers/SFibersIdentification.cc
@@ -179,7 +179,6 @@ std::vector<std::shared_ptr<identifiedFiberData>> SFibersIdentification::identif
 
         for(int i=0; i<clusters.size(); i++)
         {
-            //std::cout<<"new cluster"<<std::endl;
             for(int j=0;j<clusters[i].size();j++){
             //std::cout<<clusters[i][j][2]<<" "<<clusters[i][j][3]<<" "<<i<<" "<<clusters[i][j][4]<<std::endl;
             }
@@ -263,7 +262,6 @@ std::vector<std::shared_ptr<identifiedFiberData>> SFibersIdentification::identif
         {
             for(int j=0; j<cluster_fibers_st.size();j++)
             {
-                //std::cout<<"New pair"<<std::endl;
                 for(std::vector<std::string> fibers_bottom : cluster_fibers_sb[i])
                 {
                     for(std::vector<std::string> fibers_top : cluster_fibers_st[j])
@@ -291,7 +289,6 @@ std::vector<std::shared_ptr<identifiedFiberData>> SFibersIdentification::identif
         for(std::vector<std::vector<std::string>> k :cluster_in_fibers)
         {
             if(k.size()==1){
-               //std::cout<<"tak"<<std::endl;
                for(int i : scat_bottom[std::stoi(k[0][4])]){
                 qdc_l=qdc_l+hits[i]->energy;
                 time_l=hits[i]->time;
@@ -306,7 +303,7 @@ std::vector<std::shared_ptr<identifiedFiberData>> SFibersIdentification::identif
                 fibData->timeR=time_r;
                 fibData->mod=std::stoi(k[0][0]);
                 fibData->lay=std::stoi(k[0][1]);
-                fibData->fi=std::stoi(k[0][1]);
+                fibData->fi=std::stoi(k[0][2]);
                 allFibData.push_back(fibData);
             }
         }
@@ -330,8 +327,5 @@ std::vector<std::shared_ptr<identifiedFiberData>> SFibersIdentification::identif
              clusters.clear();
              clusters_final.clear();
              
-             
-    
 return allFibData;    
 }
-

--- a/lib/fibers/SFibersIdentification.h
+++ b/lib/fibers/SFibersIdentification.h
@@ -31,7 +31,7 @@
 
 #include "STask.h"
 
-class SFibersLookupTable;
+class SSiPMsLookupTable;
 class SLocator;
 
 struct fibAddress

--- a/lib/fibers/SFibersLookup.cc
+++ b/lib/fibers/SFibersLookup.cc
@@ -55,3 +55,36 @@ void SFibersChannel::fromHash(uint64_t hash)
     SLookupChannel::fromHash(hash);
     side = hash >> 32 & 0xff;
 }
+
+uint SSiPMsChannel::read(const char* buffer)
+{
+    uint n;
+    int cnt = sscanf(buffer, "%hu" "%hu" "%hu" "%hu" "%*[ ]%c %n", &m, &l, &element, &s, &side, &n);
+    assert(cnt == 5);
+    return n;
+}
+
+uint SSiPMsChannel::write(char* buffer, size_t n) const
+{
+    uint cnt = snprintf(buffer, n, "%3d  %3d  %3d  %3d  %c", m, l, element, s, side);
+    if (cnt < 0) return cnt;
+    if (cnt < n) return 0;
+    return cnt;
+}
+
+void SSiPMsChannel::print(bool newline, const char* prefix) const
+{
+    printf("%s %d  %d  %d %d  %c", prefix, m, l, element, s, side);
+    if (newline) putchar('\n');
+}
+
+uint64_t SSiPMsChannel::quickHash() const
+{
+    return SLookupChannel::quickHash() | (uint64_t)side << 32;
+}
+
+void SSiPMsChannel::fromHash(uint64_t hash)
+{
+    SLookupChannel::fromHash(hash);
+    side = hash >> 32 & 0xff;
+}

--- a/lib/fibers/SFibersLookup.cc
+++ b/lib/fibers/SFibersLookup.cc
@@ -26,14 +26,14 @@ A unpacker task.
 uint SFibersChannel::read(const char* buffer)
 {
     uint n;
-    int cnt = sscanf(buffer, "%hu" "%hu" "%hu" "%hu" "%*[ ]%c %n", &m, &l, &element, &s, &side, &n);
-    assert(cnt == 5);
+    int cnt = sscanf(buffer, "%2" SCNu8 "%2" SCNu8 "%2" SCNu8 "%*[ ]%c %n", &m, &l, &s, &side, &n);
+    assert(cnt == 4);
     return n;
 }
 
 uint SFibersChannel::write(char* buffer, size_t n) const
 {
-    uint cnt = snprintf(buffer, n, "%3d  %3d  %3d  %3d  %c", m, l, element, s, side);
+    uint cnt = snprintf(buffer, n, "%3d  %3d  %3d   %c", m, l, s, side);
     if (cnt < 0) return cnt;
     if (cnt < n) return 0;
     return cnt;
@@ -41,7 +41,7 @@ uint SFibersChannel::write(char* buffer, size_t n) const
 
 void SFibersChannel::print(bool newline, const char* prefix) const
 {
-    printf("%s %d  %d  %d %d  %c", prefix, m, l, element, s, side);
+    printf("%s %d  %d  %d  %c", prefix, m, l, s, side);
     if (newline) putchar('\n');
 }
 

--- a/lib/fibers/SFibersLookup.h
+++ b/lib/fibers/SFibersLookup.h
@@ -54,4 +54,31 @@ public:
     }
 };
 
+struct SIFI_EXPORT SSiPMsChannel : public SLookupChannel
+{
+    uint16_t m, l, f, element, s;
+    char side; ///< side of a fiber, either 'l' or 'r'
+
+    SSiPMsChannel() {}
+    virtual ~SSiPMsChannel() {}
+
+    virtual uint read(const char* buffer) override;
+    virtual uint write(char* buffer, size_t n) const override;
+    virtual void print(bool newline = true, const char* prefix = "") const override;
+    virtual uint64_t quickHash() const override;
+    virtual void fromHash(uint64_t hash) override;
+};
+
+class SIFI_EXPORT SSiPMsLookupTable : public SLookupTable
+{
+public:
+    using SLookupTable::SLookupTable;
+    virtual ~SSiPMsLookupTable() = default;
+
+    // methods
+    virtual std::unique_ptr<SLookupChannel> createChannel() const override
+    {
+        return std::make_unique<SSiPMsChannel>();
+    }
+};
 #endif /* SFIBERSLOOKUP_H */

--- a/lib/fibers/SFibersLookup.h
+++ b/lib/fibers/SFibersLookup.h
@@ -28,7 +28,6 @@
  */
 struct SIFI_EXPORT SFibersChannel : public SLookupChannel
 {
-    uint16_t m, l, f, element, s;
     char side; ///< side of a fiber, either 'l' or 'r'
 
     SFibersChannel() {}

--- a/lib/fibers/SSiPMCluster.cc
+++ b/lib/fibers/SSiPMCluster.cc
@@ -24,7 +24,7 @@
 void SSiPMCluster::Clear(Option_t* opt)
 {
     point.Clear();
-//    errors.Clear();
+    errors.Clear();
     hits.clear();
 }
 
@@ -33,7 +33,7 @@ void SSiPMCluster::print() const
 //    printf("SiPM CLUSTER:  module = %d  cluster = %d  x,y,z = (%f, %f, %f) +/- (%f, %f, %f)\n",
 //           module, cluster, point.x(), point.y(), point.z(), errors.x(), errors.y(), errors.z());
     
-    printf("SiPM CLUSTER: cluster = %d num of hits = %d x,y,z = (%f, %f, %f)\n", cluster, hits.size(), point.x(), point.y(), point.z());
+    printf("SiPM CLUSTER: cluster = %d num of hits = %ld x,y,z = (%f, %f, %f)\n", cluster, hits.size(), point.x(), point.y(), point.z());
     printf("SiPM HITS:\n");
     
     for(auto & h : hits) {

--- a/lib/fibers/SSiPMCluster.h
+++ b/lib/fibers/SSiPMCluster.h
@@ -30,13 +30,13 @@ protected:
     Int_t cluster{-1}; ///< address - cluster ID
     
     TVector3 point;  ///< cluster position
-//    TVector3 errors; ///< cluster position errors
+    TVector3 errors; ///< cluster position errors
     
     std::vector<Int_t> hits; ///< list of hits belonging to the cluster
     
 public:
 
-    SCategory * catSiPMsHit;
+    SCategory * catSiPMsHit; //!
     
     /// Default constructor
     SSiPMCluster() = default;
@@ -94,13 +94,13 @@ public:
     /// \return errors of the cluster position
     TVector3 & getErrors()
     {
-//        return errors;
+        return errors;
     }
     
     /// \copydoc getErrors()
     const TVector3 & getErrors() const
     {
-//        return errors;
+        return errors;
     }
     
     /// Printing details of the object.

--- a/lib/fibers/SSiPMClusterFinder.cc
+++ b/lib/fibers/SSiPMClusterFinder.cc
@@ -64,7 +64,7 @@ bool checkIfNeighbours(SSiPMHit* hit_1, SSiPMHit* hit_2)
 {
  
     /// TODO checking if two given sipms are neighbours
-    
+    return true;    
 }
 
 bool SSiPMClusterFinder::execute()


### PR DESCRIPTION
The incompletely defined FibersCalibratorPar container was partially the problem. The version I am using is copied to `/scratch1/gccb/data/TOFPET2/results/mark_sifi_params_000.txt`. 
The address for SSiPMsChannel and SFibersChannel had to be defined differently as the SFibersCalibrator uses the SFibersChannel's definition.
Other issues include:
- The SCategory object size defined in dst_4to1 determines the max module, layer and fiber (also swSiPMID) numbers but it is not read from the params.txt file.
- adding lookup tables into memory and getting them had to be done in many places in the code.
- Multiple inherited classes exist inside a 'main' class (main as determined by the file name)
- The SFibersIdentification algorithm requires further checks, the results seem correct but there obvious periodic gaps.
![layer_fiber](https://user-images.githubusercontent.com/1140150/211211676-85d4c7a7-35a4-40ba-a8b8-d609eab85543.png)
from `sifi_dst_4to1 0x1000::/scratch1/gccb/data/TOFPET2/root/raw00449_single.root -i 0 -e 100000 -p params.txt -o output.root`